### PR TITLE
use asdcplib to unwrap audio instead of BMX mxf2raw

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Note 1:
 
 2. Get x264 Encoder [x264](http://www.videolan.org/developers/x264.html). 10-bit version must be used!
 
-3. Get BMX: bmx2raw and raw2bmx applications [BMX](https://sourceforge.net/projects/bmxlib/).
+3. Get BMX: raw2bmx application [BMX](https://sourceforge.net/projects/bmxlib/).
 
 4. Get ASDCP tool. Please build it from https://github.com/DSRCorporation/asdcplib-as02 repository.
 This is a fork from from http://www.cinecert.com/asdcplib/ which is enhanced to work properly with TTML wrapped in MXF.
@@ -113,7 +113,6 @@ There is a Windows distribution there which can be used out of the box on Window
             <tool id="ffmpeg">ffmpeg</tool>
             <tool id="ffprobe">ffprobe</tool>
             <tool id="bmx">raw2bmx</tool>
-            <tool id="mxf2raw">mxf2raw</tool>
             <tool id="x264">x264-10bit</tool>
             <tool id="asdcp-unwrap">as-02-unwrap</tool>
     </externalTools>

--- a/acceptance/CPL/chimera25/CPL-short.xml
+++ b/acceptance/CPL/chimera25/CPL-short.xml
@@ -32,6 +32,7 @@
                             <Id>urn:uuid:ef11a2bb-0a2c-4a17-875c-38e3b0f8283e</Id>
                             <EditRate>25 1</EditRate>
                             <IntrinsicDuration>2400</IntrinsicDuration>
+                            <EntryPoint>1000</EntryPoint>
                             <SourceDuration>100</SourceDuration>
                             <SourceEncoding>urn:uuid:ac153e09-76ef-451e-b6cd-461d4c0aa484</SourceEncoding>
                             <TrackFileId>urn:uuid:446892a5-940e-4c91-8c62-2852fec48b2a</TrackFileId>
@@ -46,6 +47,7 @@
                             <Id>urn:uuid:e590caf1-4b3c-4a61-b039-98e007741ade</Id>
                             <EditRate>48000 1</EditRate>
                             <IntrinsicDuration>4608000</IntrinsicDuration>
+                            <EntryPoint>1920000</EntryPoint>
                             <SourceDuration>192000</SourceDuration>
                             <SourceEncoding>urn:uuid:b6c775c7-4950-4c0c-92b8-0032d6014abb</SourceEncoding>
                             <TrackFileId>urn:uuid:c23aae7e-fc10-46ad-a62d-b8ffec8dd32c</TrackFileId>

--- a/acceptance/config.xml
+++ b/acceptance/config.xml
@@ -12,7 +12,6 @@
         <tool id="ffmpeg">ffmpeg</tool>
         <tool id="ffprobe">ffprobe</tool>
         <tool id="bmx">raw2bmx</tool>
-        <tool id="mxf2raw">mxf2raw</tool>
         <tool id="x264">x264</tool>
         <tool id="as-02-unwrap">as-02-unwrap</tool>
         <!--<tool id="java">java</tool>-->

--- a/acceptance/dpp/run/dpp.bat
+++ b/acceptance/dpp/run/dpp.bat
@@ -12,7 +12,7 @@ if [%6]==[] SET PROG="..\..\..\install\imf-conversion-utility\bin\imf-conversion
 
 @echo on
 @echo STARTING: %~5
-%PROG% dpp -c ..\..\config.xml -m convert --imp %1 --cpl %2 -w %3 --metadata %4 -o %5 -l info
+%PROG% dpp -c ..\..\config.xml -m convert --imp %1 --cpl %2 -w %3 --metadata %4 -o %5 -l debug
 @echo FINISHED: %~5
 @echo
 @echo off

--- a/dpp-conversion/src/main/resources/xml/dpp-conversion.xml
+++ b/dpp-conversion/src/main/resources/xml/dpp-conversion.xml
@@ -109,14 +109,14 @@
                     <execEachSequence type="audio" name="extractAudioSegments">
                         <execEachSegment name="extract_audio">
                             <execOnce name="extract_audio">
-                                "%{tool.mxf2raw}" -p "%{seq.num}-%{segm.num}-%{resource.num}" --start
-                                %{resource.startTimeFrameEU}
-                                --dur %{resource.durationFrameEU} "%{resource.essence}"
+                                "%{tool.as-02-unwrap}"
+                                "%{resource.essence}"
+                                %{seq.num}-%{segm.num}-%{resource.num}.wav
                             </execOnce>
                             <!-- to delete intermediate files at the end -->
                             <dynamicParameter name="audio-segment-tmp-%{seq.num}-%{segm.num}-%{resource.num}"
                                               deleteOnExit="true">
-                                %{seq.num}-%{segm.num}-%{resource.num}_a0.raw
+                                %{seq.num}-%{segm.num}-%{resource.num}.wav
                             </dynamicParameter>
                         </execEachSegment>
                     </execEachSequence>
@@ -130,8 +130,10 @@
                             <cycle>
                                 <execEachSegment name="decode_audio">
                                     <execOnce name="decode_audio">
-                                        "%{tool.ffmpeg}" -f s%{resource.bits_per_sample}le -ar %{resource.sample_rate}
+                                        "%{tool.ffmpeg}" -y -f wav
                                         -ac %{resource.channels_num}
+                                        -ss %{resource.startTimeTC}
+                                        -t %{resource.durationTC}
                                         -i "%{dynamic.audio-segment-tmp-%{seq.num}-%{segm.num}-%{resource.num}}" -vn -af
                                         aresample=%{dest.sampleRate}
                                         -acodec pcm_s%{dest.bitsSample}le -f s%{dest.bitsSample}le -
@@ -139,7 +141,7 @@
                                 </execEachSegment>
                             </cycle>
                             <execOnce name="encode_audio">
-                                "%{tool.ffmpeg}" -f s%{dest.bitsSample}le -ar %{dest.sampleRate} -ac %{seq.channels_num} -i - -vn -c:a
+                                "%{tool.ffmpeg}" -y -f s%{dest.bitsSample}le -ar %{dest.sampleRate} -ac %{seq.channels_num} -i - -vn -c:a
                                 copy -f wav %{seq.num}-audio-encoded.wav
                             </execOnce>
                         </pipe>
@@ -163,7 +165,7 @@
                         4. Remap audio in accordance with AudioMap.xml
                     -->
                     <execOnce name="audioMaping" if="%{dynamic.hasAudio}">
-                        "%{tool.ffmpeg}" %{dynamic.concatAudioInput} -filter_complex
+                        "%{tool.ffmpeg}" -y %{dynamic.concatAudioInput} -filter_complex
                         "%{dynamic.concatAudioMap}amerge,pan=%{dynamic.panParameter}[aout]"
                         -map "[aout]" -acodec pcm_s%{dest.bitsSample}le -ar %{dest.sampleRate} -f s%{dest.bitsSample}le "%{tmp.audioEncoded}"
                     </execOnce>

--- a/sample/config.xml
+++ b/sample/config.xml
@@ -12,7 +12,6 @@
         <tool id="ffmpeg">ffmpeg</tool>
         <tool id="ffprobe">ffprobe</tool>
         <tool id="bmx">raw2bmx</tool>
-        <tool id="mxf2raw">mxf2raw</tool>
         <tool id="x264">x264</tool>
         <tool id="as-02-unwrap">as-02-unwrap</tool>
         <!--<tool id="ttml-to-stl">ttml-to-stl.jar</tool>-->

--- a/sample/quick_start.txt
+++ b/sample/quick_start.txt
@@ -11,7 +11,7 @@ Quick Start Guide:
     1.3. Get x264 Encoder (http://www.videolan.org/developers/x264.html).
          10-bit version must be used!
 
-    1.4. Get BMX: bmx2raw and raw2bmx applications (https://sourceforge.net/projects/bmxlib/).
+    1.4. Get BMX: raw2bmx application (https://sourceforge.net/projects/bmxlib/).
 
     1.5. Get ASDCP tool. Please build it from https://github.com/DSRCorporation/asdcplib-as02 repository.
          This is a fork from from http://www.cinecert.com/asdcplib/ which is enhanced to work properly with TTML wrapped in MXF.


### PR DESCRIPTION
The latest version of mxf2raw fails if an input audio mxf contains no MCA channel label ID. 